### PR TITLE
Update on how to obtain cookie

### DIFF
--- a/packages/core/doc/README.en.md
+++ b/packages/core/doc/README.en.md
@@ -49,7 +49,7 @@ Use cookies of hoyolab site to login to the instance.
 
 > **⚠️ Caution ⚠️**：Please keep your cookies safe.<br>NEVER SHARE YOUR COOKIES WITH ANYONE ELSE!
 
-**How to obtain**: login to hoyolab <https://www.hoyolab.com/genshin/>, then input `document.cookie` in the browser console, it returns the cookies you need. Usually the cookies you obtained can be used for some time; if it fails, try to obtain another one.
+**How to obtain**: login to hoyolab Battle Chronicle <https://webstatic-sea.mihoyo.com/app/community-game-records-sea/#/ys>, then input `document.cookie` in the browser console, it returns the cookies you need. Usually the cookies you obtained can be used for some time; if it fails, try to obtain another one.
 
 <details>
 <summary>Usage Example</summary>


### PR DESCRIPTION
Due to recent change in hoyolab website
https://www.hoyolab.com/ no longer hold tokens in the cookie anymore
but Battle Chronicle still have the cookie.